### PR TITLE
Use formatted New York timestamps in HTML renderer

### DIFF
--- a/src/ui/html.ts
+++ b/src/ui/html.ts
@@ -1,3 +1,5 @@
+import { formatNY } from "../utils/dates";
+
 export function renderHTML(data: any) {
   const results = (data?.results ?? []) as any[];
 
@@ -93,7 +95,7 @@ export function renderHTML(data: any) {
     <div class="hero">
       <div>
         <div class="title">LEAPS Candidates</div>
-        <div class="subtitle">Last run: ${data?.ts ?? "—"} • Click headers to sort • Search to filter</div>
+        <div class="subtitle">Last run: ${formatNY(data?.ts)} • Click headers to sort • Search to filter</div>
       </div>
       <div class="controls">
         <label class="pill">🔎 <input id="q" placeholder="Filter symbols & text…" /></label>

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -4,3 +4,12 @@ export function getQueryParamList(url: URL, key: string): string[] | null {
   if (!val) return null;
   return val.split(',').map((s) => s.trim().toUpperCase()).filter(Boolean);
 }
+
+export function formatNY(iso: string | null): string {
+  if (!iso) return "—";
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone: "America/New_York",
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(iso));
+}


### PR DESCRIPTION
## Summary
- add `formatNY` helper to normalize ISO timestamps to New York time
- display formatted last-run time in HTML renderer

## Testing
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68c72e2e53608328ba100a5a5d995229